### PR TITLE
Fix(#8)-dashboard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,14 +28,15 @@ ext {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    //implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    //runtimeOnly 'com.mysql:mysql-connector-j'
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/modive/adminservice/api/user/controller/UserController.java
+++ b/src/main/java/com/modive/adminservice/api/user/controller/UserController.java
@@ -195,7 +195,7 @@ public class UserController {
             @PathVariable("userId") Long userId,
 
             @Parameter(name = "pageSize", description = "한 번에 가져올 항목 수", example = "10", required = false)
-            @RequestParam int pageSize,
+            @RequestParam (name = "pageSize", required = false) Integer pageSize,
 
             @Parameter(name = "startTime", description = "커서: 마지막 항목의 startTime (최신순)", example = "2024-05-20T12:34:56Z", required = false)
             @RequestParam(name = "startTime", required = false) String startTime,
@@ -209,6 +209,8 @@ public class UserController {
         data.put("driveHistory", result.getDriveHistory());
         data.put("startTime", result.getStartTime());
         data.put("driveId", result.getDriveId());
+
+        System.out.println(data);
 
         return new ResponseEntity<>(
                 CommonRes.success(data, "사용자 운전 내역 조회에 성공하였습니다."),

--- a/src/main/java/com/modive/adminservice/api/user/controller/UserController.java
+++ b/src/main/java/com/modive/adminservice/api/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.modive.adminservice.api.user.controller;
 
+import com.modive.adminservice.api.user.dto.res.UserDriveListRes;
 import com.modive.adminservice.global.dto.res.CommonRes;
 import com.modive.adminservice.global.error.dto.ErrorRes;
 import com.modive.adminservice.api.user.dto.req.UserFilterReq;
@@ -34,9 +35,9 @@ public class UserController {
     @Operation(summary = "사용자 전체 목록 조회", description = "등록된 전체 사용자를 페이징으로 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Success",
-            content = {@Content(schema = @Schema(implementation = CommonRes.class))}),
+                    content = {@Content(schema = @Schema(implementation = CommonRes.class))}),
             @ApiResponse(responseCode = "500", description = "Internal Server Error",
-                content = {@Content(schema = @Schema(implementation = ErrorRes.class))})
+                    content = {@Content(schema = @Schema(implementation = ErrorRes.class))})
     })
     public ResponseEntity<CommonRes> getUserList(
             @Parameter(name = "page", description = "페이지 번호", example = "1", required = true)
@@ -61,7 +62,7 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "Success",
                     content = {@Content(schema = @Schema(implementation = CommonRes.class))}),
             @ApiResponse(responseCode = "500", description = "Internal Server Error",
-                content = {@Content(schema = @Schema(implementation = ErrorRes.class))})
+                    content = {@Content(schema = @Schema(implementation = ErrorRes.class))})
     })
     public ResponseEntity<CommonRes> searchUser(
             @Parameter(name = "searchKeyword", description = "사용자 이메일", example = "user@modive.com", required = true)
@@ -179,8 +180,8 @@ public class UserController {
         );
     }
 
-    @GetMapping("/{userId}/drives")
-    @Operation(summary = "사용자 주행 이력 조회", description = "userId 기준으로 운전 기록을 페이징으로 조회합니다.")
+    @GetMapping("/drives/{userId}")
+    @Operation(summary = "사용자 주행 이력 조회(무한 스크롤)", description = "userId 기준으로 최신순 주행 기록을 커서 기반으로 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Success",
                     content = {@Content(schema = @Schema(implementation = CommonRes.class))}),
@@ -193,16 +194,21 @@ public class UserController {
             @Schema(description = "유저 ID", example = "1")
             @PathVariable("userId") Long userId,
 
-            @Parameter(name = "page", description = "페이지 번호", example = "2", required = true)
-            @RequestParam int page,
+            @Parameter(name = "pageSize", description = "한 번에 가져올 항목 수", example = "10", required = false)
+            @RequestParam int pageSize,
 
-            @Parameter(name = "pageSize", description = "페이지당 항목 수", example = "10", required = true)
-            @RequestParam int pageSize
+            @Parameter(name = "startTime", description = "커서: 마지막 항목의 startTime (최신순)", example = "2024-05-20T12:34:56Z", required = false)
+            @RequestParam(name = "startTime", required = false) String startTime,
+
+            @Parameter(name = "driveId", description = "커서: 마지막 항목의 driveId", example = "abc123", required = false)
+            @RequestParam(name = "driveId", required = false) String driveId
     ) {
-        List<UserDriveListItem> driveListItems = userAdminService.adminGetUserDriveList(userId, page, pageSize);
+        UserDriveListRes result = userAdminService.adminGetUserDriveList(userId, pageSize, startTime, driveId);
 
         Map<String, Object> data = new HashMap<>();
-        data.put("driveHistory", driveListItems);
+        data.put("driveHistory", result.getDriveHistory());
+        data.put("startTime", result.getStartTime());
+        data.put("driveId", result.getDriveId());
 
         return new ResponseEntity<>(
                 CommonRes.success(data, "사용자 운전 내역 조회에 성공하였습니다."),
@@ -210,3 +216,4 @@ public class UserController {
         );
     }
 }
+

--- a/src/main/java/com/modive/adminservice/api/user/dto/res/UserDriveListRes.java
+++ b/src/main/java/com/modive/adminservice/api/user/dto/res/UserDriveListRes.java
@@ -1,0 +1,15 @@
+package com.modive.adminservice.api.user.dto.res;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDriveListRes {
+    private List<UserDriveListItem> driveHistory;  // 주행 이력
+    private String startTime;                      // 커서
+    private String driveId;                        // 커서
+}

--- a/src/main/java/com/modive/adminservice/api/user/service/UserAdminService.java
+++ b/src/main/java/com/modive/adminservice/api/user/service/UserAdminService.java
@@ -2,6 +2,7 @@ package com.modive.adminservice.api.user.service;
 
 import com.modive.adminservice.api.user.dto.req.UserFilterReq;
 import com.modive.adminservice.api.user.dto.res.UserDriveListItem;
+import com.modive.adminservice.api.user.dto.res.UserDriveListRes;
 import com.modive.adminservice.api.user.dto.res.UserListItem;
 import com.modive.adminservice.api.user.dto.res.UserRewardItem;
 
@@ -14,5 +15,5 @@ public interface UserAdminService {
     List<UserListItem> adminFilterUser(UserFilterReq req);
     void adminInactiveUser(Long userId);
     List<UserRewardItem> adminGetUserReward(Long userId, int page, int pageSize);
-    List<UserDriveListItem> adminGetUserDriveList(Long userId, int page, int pageSize);
+    UserDriveListRes adminGetUserDriveList(Long userId, int pageSize, String startTime, String driveId);
 }

--- a/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
+++ b/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
@@ -261,27 +261,24 @@ public class UserAdminServiceImpl implements UserAdminService {
         List<DCDriveListItem> drives = dashboardRes.getDriveHistory().getList();
 
         List<Long> driveIds = extractDriveIds(drives);
-//        Map<Long, Integer> rewardMap = rewardFetchService.fetchRewardMapByDrive(new RCRewardByDriveReq(driveIds));
-//        Map<Long, List<EventsByDriveDTO>> events = analysisFetchService.getTotalEventCntByType(driveIds);
+        Map<Long, Integer> rewardMap = rewardFetchService.fetchRewardMapByDrive(new RCRewardByDriveReq(driveIds));
+        Map<Long, List<EventsByDriveDTO>> events = analysisFetchService.getTotalEventCntByType(driveIds);
 
-        // ✅ Mock: 리워드 맵을 빈 값 또는 더미 값으로 대체
-        Map<Long, Integer> rewardMap = new HashMap<>();
-        for (Long driveIdItem : driveIds) {
-            rewardMap.put(driveIdItem, 1); // 또는 임의의 값 (예: 10)
-        }
-
-        // ✅ Mock: 이벤트 맵도 빈 값 또는 더미 이벤트로 대체
-        Map<Long, List<EventsByDriveDTO>> events = new HashMap<>();
-        for (Long driveIdItem : driveIds) {
-            events.put(driveIdItem, List.of(
-                    new EventsByDriveDTO("SPEEDING", 1L),
-                    new EventsByDriveDTO("HARSH_BRAKING", 2L)
-            ));
-        }
-
+//        // 테스트용 Mock: 리워드 맵을 빈 값 또는 더미 값으로 대체
+//        Map<Long, Integer> rewardMap = new HashMap<>();
+//        for (Long driveIdItem : driveIds) {
+//            rewardMap.put(driveIdItem, 1); // 또는 임의의 값 (예: 10)
+//        }
+//
+//        // 테스트용 Mock: 이벤트 맵도 빈 값 또는 더미 이벤트로 대체
+//        Map<Long, List<EventsByDriveDTO>> events = new HashMap<>();
+//        for (Long driveIdItem : driveIds) {
+//            events.put(driveIdItem, List.of(
+//                    new EventsByDriveDTO("SPEEDING", 1L),
+//                    new EventsByDriveDTO("HARSH_BRAKING", 2L)
+//            ));
+//        }
         List<UserDriveListItem> enriched = enrichDriveItems(drives, rewardMap, events);
-
-        log.info("Dashboard Response: {}", dashboardRes);
 
         return UserDriveListRes.builder()
                 .driveHistory(enriched)

--- a/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
+++ b/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
@@ -258,18 +258,35 @@ public class UserAdminServiceImpl implements UserAdminService {
     @Override
     public UserDriveListRes adminGetUserDriveList(Long userId, int pageSize, String startTime, String driveId ) {
         DCDriveListResData dashboardRes = dashboardFetchService.fetchDriveListByUserId(userId, pageSize, startTime, driveId);
-        List<DCDriveListItem> drives = dashboardRes.getDriveHistory();
+        List<DCDriveListItem> drives = dashboardRes.getDriveHistory().getList();
 
         List<Long> driveIds = extractDriveIds(drives);
-        Map<Long, Integer> rewardMap = rewardFetchService.fetchRewardMapByDrive(new RCRewardByDriveReq(driveIds));
-        Map<Long, List<EventsByDriveDTO>> events = analysisFetchService.getTotalEventCntByType(driveIds);
+//        Map<Long, Integer> rewardMap = rewardFetchService.fetchRewardMapByDrive(new RCRewardByDriveReq(driveIds));
+//        Map<Long, List<EventsByDriveDTO>> events = analysisFetchService.getTotalEventCntByType(driveIds);
 
-        List<UserDriveListItem> enriched = enrichDriveItems(drives, rewardMap,events);
+        // ✅ Mock: 리워드 맵을 빈 값 또는 더미 값으로 대체
+        Map<Long, Integer> rewardMap = new HashMap<>();
+        for (Long driveIdItem : driveIds) {
+            rewardMap.put(driveIdItem, 1); // 또는 임의의 값 (예: 10)
+        }
+
+        // ✅ Mock: 이벤트 맵도 빈 값 또는 더미 이벤트로 대체
+        Map<Long, List<EventsByDriveDTO>> events = new HashMap<>();
+        for (Long driveIdItem : driveIds) {
+            events.put(driveIdItem, List.of(
+                    new EventsByDriveDTO("SPEEDING", 1L),
+                    new EventsByDriveDTO("HARSH_BRAKING", 2L)
+            ));
+        }
+
+        List<UserDriveListItem> enriched = enrichDriveItems(drives, rewardMap, events);
+
+        log.info("Dashboard Response: {}", dashboardRes);
 
         return UserDriveListRes.builder()
                 .driveHistory(enriched)
-                .startTime(dashboardRes.getStartTime())
-                .driveId(dashboardRes.getDriveId())
+                .startTime(dashboardRes.getDriveHistory().getStartTime())
+                .driveId(dashboardRes.getDriveHistory().getDriveId())
                 .build();
     }
 }

--- a/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
+++ b/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
@@ -3,7 +3,12 @@ package com.modive.adminservice.api.user.service.impl;
 //import com.modive.adminservice.external.client.reward.RewardClient;
 import com.modive.adminservice.external.analysis.dto.EventsByDriveDTO;
 import com.modive.adminservice.external.analysis.service.AnalysisFetchService;
+
+import com.modive.adminservice.api.user.dto.res.*;
+import com.modive.adminservice.domain.event.service.EventService;
+
 import com.modive.adminservice.external.dashboard.dto.res.DCDriveListItem;
+import com.modive.adminservice.external.dashboard.dto.res.DCDriveListResData;
 import com.modive.adminservice.external.reward.client.RewardClient;
 import com.modive.adminservice.external.reward.dto.req.RCRewardByDriveReq;
 import com.modive.adminservice.external.reward.dto.req.RCRewardFilterReq;
@@ -12,10 +17,6 @@ import com.modive.adminservice.external.user.dto.res.UCUserDetailResData;
 import com.modive.adminservice.external.user.dto.res.UCUserListItem;
 import com.modive.adminservice.global.util.DateUtils;
 import com.modive.adminservice.api.user.dto.req.UserFilterReq;
-import com.modive.adminservice.api.user.dto.res.UserDriveListEventItem;
-import com.modive.adminservice.api.user.dto.res.UserDriveListItem;
-import com.modive.adminservice.api.user.dto.res.UserListItem;
-import com.modive.adminservice.api.user.dto.res.UserRewardItem;
 import com.modive.adminservice.external.dashboard.service.DashboardFetchService;
 import com.modive.adminservice.external.reward.service.RewardFetchService;
 import com.modive.adminservice.external.user.service.UserFetchService;
@@ -250,18 +251,27 @@ public class UserAdminServiceImpl implements UserAdminService {
      * 사용자의 운전 내역 조회
      *
      * @param userId 유저 ID
-     * @param page 페이지 번호
-     * @param pageSize 페이지당 데이터 개수
+     * @param pageSize 한 번에 가져올 항목 수
+     * @param startTime [커서] 마지막 startTime
+     * @param driveId [커서] 마지막 driveId
      * @return 운전 내역 리스트
      */
     @Override
-    public List<UserDriveListItem> adminGetUserDriveList(Long userId, int page, int pageSize) {
-        List<DCDriveListItem> drives = dashboardFetchService.fetchDriveListByUserId(userId);
+    public UserDriveListRes adminGetUserDriveList(Long userId, int pageSize, String startTime, String driveId ) {
+        DCDriveListResData dashboardRes = dashboardFetchService.fetchDriveListByUserId(userId, pageSize, startTime, driveId);
+        List<DCDriveListItem> drives = dashboardRes.getDriveHistory();
 
         List<Long> driveIds = extractDriveIds(drives);
         Map<Long, Integer> rewardMap = rewardFetchService.fetchRewardMapByDrive(new RCRewardByDriveReq(driveIds));
         Map<Long, List<EventsByDriveDTO>> events = analysisFetchService.getTotalEventCntByType(driveIds);
 
-        return enrichDriveItems(drives, rewardMap, events);
+        // return enrichDriveItems(drives, rewardMap, events);
+        List<UserDriveListItem> enriched = enrichDriveItems(drives, rewardMap,events);
+
+        return UserDriveListRes.builder()
+                .driveHistory(enriched)
+                .startTime(dashboardRes.getStartTime())
+                .driveId(dashboardRes.getDriveId())
+                .build();
     }
 }

--- a/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
+++ b/src/main/java/com/modive/adminservice/api/user/service/impl/UserAdminServiceImpl.java
@@ -5,7 +5,6 @@ import com.modive.adminservice.external.analysis.dto.EventsByDriveDTO;
 import com.modive.adminservice.external.analysis.service.AnalysisFetchService;
 
 import com.modive.adminservice.api.user.dto.res.*;
-import com.modive.adminservice.domain.event.service.EventService;
 
 import com.modive.adminservice.external.dashboard.dto.res.DCDriveListItem;
 import com.modive.adminservice.external.dashboard.dto.res.DCDriveListResData;
@@ -265,7 +264,6 @@ public class UserAdminServiceImpl implements UserAdminService {
         Map<Long, Integer> rewardMap = rewardFetchService.fetchRewardMapByDrive(new RCRewardByDriveReq(driveIds));
         Map<Long, List<EventsByDriveDTO>> events = analysisFetchService.getTotalEventCntByType(driveIds);
 
-        // return enrichDriveItems(drives, rewardMap, events);
         List<UserDriveListItem> enriched = enrichDriveItems(drives, rewardMap,events);
 
         return UserDriveListRes.builder()

--- a/src/main/java/com/modive/adminservice/external/dashboard/client/DashBoardClient.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/client/DashBoardClient.java
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * dashboard-service와 통신하는 Feign Client.
  */
-@FeignClient(name="dashboard-service")
+@FeignClient(name = "dashboard-service")
 public interface DashBoardClient {
 
     /**
@@ -32,7 +32,7 @@ public interface DashBoardClient {
     @GetMapping("/dashboard/drives/{userId}")
     CommonRes<DCDriveListResData> getDrivesByUserId(
             @PathVariable("userId") Long userId,
-            @RequestParam(name = "pageSize") int pageSize,
+            @RequestParam(name = "pageSize" , required = false) int pageSize,
             @RequestParam(name = "startTime", required = false) String startTime,
             @RequestParam(name = "driveId", required = false) String driveId
     );
@@ -42,3 +42,4 @@ public interface DashBoardClient {
     @GetMapping("/dashboard/drives/monthly-stats")
     CommonRes getMonthlyStats();
 }
+

--- a/src/main/java/com/modive/adminservice/external/dashboard/client/DashBoardClient.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/client/DashBoardClient.java
@@ -1,11 +1,9 @@
 package com.modive.adminservice.external.dashboard.client;
 
+import com.modive.adminservice.external.dashboard.dto.res.DCDriveListResData;
 import com.modive.adminservice.global.dto.res.CommonRes;
 import org.springframework.cloud.openfeign.FeignClient;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Map;
@@ -31,9 +29,13 @@ public interface DashBoardClient {
      * @param userId 운전 내역 조회 대상 유저 ID
      * @return CommonRes 형태로 사용자의 운전 내역 응답 반환
      */
-    @GetMapping("/dashboard/{userId}/drives")
-    CommonRes getDrivesByUserId(@PathVariable("userId") Long userId);
-
+    @GetMapping("/dashboard/drives/{userId}")
+    CommonRes<DCDriveListResData> getDrivesByUserId(
+            @PathVariable("userId") Long userId,
+            @RequestParam(name = "pageSize") int pageSize,
+            @RequestParam(name = "startTime", required = false) String startTime,
+            @RequestParam(name = "driveId", required = false) String driveId
+    );
     @GetMapping("/dashboard/drives/total")
     CommonRes getTotalDriveCount();
 

--- a/src/main/java/com/modive/adminservice/external/dashboard/dto/res/DCDriveListItem.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/dto/res/DCDriveListItem.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * 대시보드 서비스의 "/dashboard/{userId}/drives" API의 응답에 사용될 DTO
+ * 대시보드 서비스의 "/dashboard/drives/{userId}" API의 응답에 사용될 DTO
  * - 사용처: DashBoardClient
  */
 

--- a/src/main/java/com/modive/adminservice/external/dashboard/dto/res/DCDriveListResData.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/dto/res/DCDriveListResData.java
@@ -1,9 +1,6 @@
 package com.modive.adminservice.external.dashboard.dto.res;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
@@ -13,12 +10,15 @@ import java.util.List;
  * - 사용처: DashBoardClient
  */
 
-@Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Data
 public class DCDriveListResData {
-    private List<DCDriveListItem> driveHistory;
-    private String startTime;
-    private String driveId;
+    private DriveHistoryWrapper driveHistory;
+
+    @Data
+    public static class DriveHistoryWrapper {
+        private List<DCDriveListItem> list;
+        private String driveId;
+        private String startTime;
+    }
 }
+

--- a/src/main/java/com/modive/adminservice/external/dashboard/dto/res/DCDriveListResData.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/dto/res/DCDriveListResData.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 import java.util.List;
 
 /**
- * 대시보드 서비스의 "/dashboard/{userId}/drives" API 응답의 data 필드  DTO.
+ * 대시보드 서비스의 "/dashboard/drives/"{userId}" API 응답의 data 필드  DTO.
  * - 실제 응답 구조: { "status": ..., "message": ..., "data": { "driveHistory": [...] } }
  * - 사용처: DashBoardClient
  */
@@ -19,4 +19,6 @@ import java.util.List;
 @AllArgsConstructor
 public class DCDriveListResData {
     private List<DCDriveListItem> driveHistory;
+    private String startTime;
+    private String driveId;
 }

--- a/src/main/java/com/modive/adminservice/external/dashboard/service/DashboardFetchService.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/service/DashboardFetchService.java
@@ -1,6 +1,7 @@
 package com.modive.adminservice.external.dashboard.service;
 
 import com.modive.adminservice.external.dashboard.dto.res.DCDriveListItem;
+import com.modive.adminservice.external.dashboard.dto.res.DCDriveListResData;
 import com.modive.adminservice.external.dashboard.dto.res.DCMonthlyDriveItem;
 import com.modive.adminservice.external.dashboard.dto.res.DCTotalCntAndRateItem;
 
@@ -9,7 +10,7 @@ import java.util.Map;
 
 public interface DashboardFetchService {
     Map<Long, Integer> fetchDriveCountMap(List<Long> userIds);
-    List<DCDriveListItem> fetchDriveListByUserId(Long userId);
+    DCDriveListResData fetchDriveListByUserId(Long userId, int pageSize, String startTime, String driveId);
     DCTotalCntAndRateItem fetchDriveTotalCntAndRate();
     List<DCMonthlyDriveItem> fetchMonthlyDrivesStatistics();
 }

--- a/src/main/java/com/modive/adminservice/external/dashboard/service/impl/DashboardFetchServiceImpl.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/service/impl/DashboardFetchServiceImpl.java
@@ -46,21 +46,23 @@ public class DashboardFetchServiceImpl implements DashboardFetchService {
      }
 
     /**
-     * 대시보드 서비스에서 특정 사용자의 운전 내역 리스트 조회
+     /**
+     * 대시보드 서비스에서 특정 사용자의 운전 내역 리스트 조회 (커서 기반)
      *
      * @param userId 사용자 ID
-     * @return 운전 내역 리스트
+     * @param pageSize 페이지 크기
+     * @param startTime 커서 startTime
+     * @param driveId 커서 driveId
+     * @return 커서 정보 포함된 응답
      */
     @Override
-    public List<DCDriveListItem> fetchDriveListByUserId(Long userId) {
-        CommonRes<DCDriveListResData> res = dashBoardClient.getDrivesByUserId(userId);
+    public DCDriveListResData fetchDriveListByUserId(Long userId,int pageSize, String startTime, String driveId) {
+        CommonRes<DCDriveListResData> res = dashBoardClient.getDrivesByUserId(userId,pageSize, startTime, driveId);
         if (res == null || res.data == null) {
             log.warn("DashboardClient.getDrivesByUserId(userId = {}) - response or data is null", userId);
             throw new RestApiException(ErrorCode.FEIGN_DATA_MISSING);
         }
-
-        return res.getData().getDriveHistory();
-    }
+        return res.getData();    }
 
     /**
      *  대시보드 서비스에서 누적 주행 횟수와 증감률 조회

--- a/src/main/java/com/modive/adminservice/external/dashboard/service/impl/DashboardFetchServiceImpl.java
+++ b/src/main/java/com/modive/adminservice/external/dashboard/service/impl/DashboardFetchServiceImpl.java
@@ -1,5 +1,6 @@
 package com.modive.adminservice.external.dashboard.service.impl;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.modive.adminservice.external.dashboard.client.DashBoardClient;
 import com.modive.adminservice.external.dashboard.dto.res.*;
 import com.modive.adminservice.global.dto.res.CommonRes;
@@ -62,7 +63,12 @@ public class DashboardFetchServiceImpl implements DashboardFetchService {
             log.warn("DashboardClient.getDrivesByUserId(userId = {}) - response or data is null", userId);
             throw new RestApiException(ErrorCode.FEIGN_DATA_MISSING);
         }
-        return res.getData();    }
+        ObjectMapper mapper = new ObjectMapper();
+        DCDriveListResData parsed = mapper.convertValue(res.getData(), DCDriveListResData.class);
+
+        log.info("Dashboard Response: {}", parsed);
+        return parsed;
+    }
 
     /**
      *  대시보드 서비스에서 누적 주행 횟수와 증감률 조회

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,15 +9,6 @@ spring:
       profile: dev
       label: main
 
-eureka:
-  client:
-    service-url:
-      defaultZone: http://localhost:8761/eureka
-    register-with-eureka: true
-    fetch-registry: true
-  instance:
-    prefer-ip-address: true
-
 springdoc:
   swagger-ui:
     groups-oder: DESC

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,20 +2,6 @@ spring:
   application:
     name: admin-service
 
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/modive_event
-    username: root
-    password: ${MYSQL_PW}
-
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        format_sql: true
-    show-sql: true
-
   config:
     import: configserver:http://localhost:8888
   cloud:


### PR DESCRIPTION
## 🔍 이슈

- Close #8 

---

## 📕 작업 내역

구현한 작업 내역

> 사용자 주행 이력 조회 API에 커서 기반 페이징 기능을 적용
> 대시보드 서비스로부터 커서 정보(startTime, driveId)를 포함한 응답을 받아서
> 프론트엔드에서 무한 스크롤 방식으로 요청할 수 있도록 수정
> 

### 응답 및 요청 dto 수정
기존: 단순 리스트(List<UserDriveListItem>) 반환
변경: UserDriveListRes DTO로 응답 포장
포함 필드: `driveHistory, startTime, driveId
`
프론트는 다음 요청 시 startTime, driveId를 파라미터로 전달

### 서비스 로직 수정 
- dashboardFetchService.fetchDriveListByUserId(...) 호출 시 커서 파라미터 추가
- 대시보드 응답 DTO DCDriveListResData 사용해 driveHistory + startTime + driveId 수신
- 리워드 및 이벤트 정보 매핑 (enrichDriveItems(...))

### FeignClient 수정
- DashBoardClient.getDrivesByUserId(...)
→ CommonRes<DCDriveListResData>로 제네릭 명시
---

## 📸 스크린샷(Optional)

| 기능 | 스크린샷 |
|------|----------|
|      |          |

---

## 📋 PR 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 파일 혹은 폴더 추가

---

## ⚠️ 추가적으로 설명할 내용

- 추가적으로 설명할 내용은 없습니다.